### PR TITLE
TOPS-656 - move KMS key to CONFIGURATION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+ACCOUNT_ID = $(shell aws sts get-caller-identity | jq -r ".Account")
+BRANCH_NAME = $(shell git rev-parse --abbrev-ref HEAD)
+
+APP_NAME := envars
+PYTHON_VERSION := 3.10
+
+.DEFAULT_GOAL := help
+.PHONY: help python python-deps-upgrade test clean
+
+confirm:
+	@( read -p "$(RED)Are you sure? [y/N]$(RESET): " sure && case "$$sure" in [yY]) true;; *) false;; esac )
+
+python: ## setup python env and pre-commit
+	pyenv install -s $(PYTHON_VERSION)
+	pyenv virtualenv $(PYTHON_VERSION) $(APP_NAME)_$(BRANCH_NAME)
+	echo $(APP_NAME)_$(BRANCH_NAME) > .python-version
+	eval "$$(pyenv init -)" && \
+		pyenv activate $(APP_NAME)_$(BRANCH_NAME) && \
+		pip install --upgrade pip && \
+		pip install wheel && \
+		pip install -r requirements.txt
+	pre-commit install
+
+python-deps-upgrade: ## Run pip-complie upgrade
+	pip-compile --resolver=backtracking -U
+
+test: ## Run tests
+	pytest -v
+
+clean: confirm ## Clean python
+	rm .python-version
+	eval "$$(pyenv init -)" && pyenv virtualenv-delete -f $(APP_NAME)_$(BRANCH_NAME)
+
+help: ## This message
+	@grep -E '(^[a-zA-Z_-]+:.*?## .*$$)|(^##)' $(MAKEFILE_LIST) \
+	| awk 'BEGIN{FS=":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' \
+	| sed -e 's/\[32m##/[33m/'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-ACCOUNT_ID = $(shell aws sts get-caller-identity | jq -r ".Account")
 BRANCH_NAME = $(shell git rev-parse --abbrev-ref HEAD)
 
 APP_NAME := envars

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ python -m envars.envars
 To create an envars.yml file
 
 ```
-$ envars init --app myapp --environments prod,staging
+$ envars init --app myapp --environments prod,staging --kms-key-arn <your-arn>
 ```
 
 Add a variable default value

--- a/README.md
+++ b/README.md
@@ -2,13 +2,19 @@
 
 Command-line Python application to manage environment variables and AWS KMS encrypted secrets in a single file.
 
+## Requirements
+
+A KMS key should be created in your AWS account.
+
+further reading at https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html
+
 ## Install
 
 ```
 $ pip install git+ssh://git@github.com/timeoutdigital/envars
 ```
 
-I may publish to pypi at a later date but sadly the `envars` name is already taken
+I may publish to pypi at a later date but sadly the `envars` name is already taken.
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Command-line Python application to manage environment variables and AWS KMS encrypted secrets in a single file.
 
-## Requirements
-
-Your AWS account should have a KMS key created with an alias of `alias/envars`.
-
-further reading at https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html
-
 ## Install
 
 ```
@@ -15,6 +9,33 @@ $ pip install git+ssh://git@github.com/timeoutdigital/envars
 ```
 
 I may publish to pypi at a later date but sadly the `envars` name is already taken
+
+## Local Development
+
+Clone
+
+```
+$ git clone git@github.com:timeoutdigital/envars.git
+$ cd envars
+```
+
+Initialise
+
+```
+$ make python
+```
+
+Test
+
+```
+$ make test
+```
+
+Run
+
+```
+$ python -m envars.envars
+```
 
 ## Usage
 

--- a/envars/envars.py
+++ b/envars/envars.py
@@ -229,6 +229,10 @@ def add_var(args):
 
 
 def print_env(args):
+    print(process(args))
+
+
+def process(args):
     envars = EnVars(args.filename)
     envars.load()
 
@@ -243,7 +247,7 @@ def print_env(args):
             template_vars[tvar.split('=')[0]] = tvar.split('=')[1]
 
         if args.yaml:
-            print(
+            return(
                 yaml.dump(
                     {'envars': envars.build_env(
                         args.env,
@@ -260,7 +264,7 @@ def print_env(args):
                     account,
                     decrypt=args.decrypt,
                     template_vars=template_vars).items():
-                print(f'{name}={value}')
+                return(f'{name}={value}')
     else:
         var = None
         if args.var:

--- a/envars/envars.py
+++ b/envars/envars.py
@@ -51,6 +51,11 @@ def main():
         '--environments',
         required=True,
     )
+    parser_init.add_argument(
+        '-k',
+        '--kms-key-arn',
+        required=True,
+    )
     parser_init.set_defaults(func=init)
 
     #
@@ -201,6 +206,7 @@ def validate(args):
 def init(args):
     envars = EnVars(args.filename)
     envars.app = args.app
+    envars.kms_key_arn = args.kms_key_arn
     envars.envs = args.environments.split(',')
     envars.save()
 

--- a/envars/kms.py
+++ b/envars/kms.py
@@ -6,10 +6,9 @@ from botocore.exceptions import NoRegionError
 
 class KMSAgent(object):
 
-    key_id = 'arn:aws:kms:eu-west-1:511042647617:key/fa5e3309-6af0-4df2-afd2-b21d480beaf4'
-
-    def __init__(self):
+    def __init__(self, kms_key_arn):
         self.cache = {}
+        self.kms_key_arn = kms_key_arn
 
     def reset(self):
         self.cache = {}
@@ -43,7 +42,7 @@ class KMSAgent(object):
             pass
 
         response = self.kms_client.encrypt(
-            KeyId=self.key_id,
+            KeyId=self.kms_key_arn,
             Plaintext=plaintext.encode('utf-8'),
             EncryptionContext=encryption_context
         )
@@ -53,6 +52,3 @@ class KMSAgent(object):
 
     def _cache_key(self, plaintext, encryption_context):
         return (plaintext,) + tuple(sorted(encryption_context.items()))
-
-
-kms_agent = KMSAgent()

--- a/envars/kms.py
+++ b/envars/kms.py
@@ -6,7 +6,7 @@ from botocore.exceptions import NoRegionError
 
 class KMSAgent(object):
 
-    key_id = 'alias/envars'
+    key_id = 'arn:aws:kms:eu-west-1:511042647617:key/fa5e3309-6af0-4df2-afd2-b21d480beaf4'
 
     def __init__(self):
         self.cache = {}

--- a/envars/kms.py
+++ b/envars/kms.py
@@ -7,7 +7,6 @@ from botocore.exceptions import NoRegionError
 class KMSAgent(object):
 
     key_id = 'arn:aws:kms:eu-west-1:511042647617:key/fa5e3309-6af0-4df2-afd2-b21d480beaf4'
-    key_id = 'alias/envars'
 
     def __init__(self):
         self.cache = {}

--- a/envars/kms.py
+++ b/envars/kms.py
@@ -7,6 +7,7 @@ from botocore.exceptions import NoRegionError
 class KMSAgent(object):
 
     key_id = 'arn:aws:kms:eu-west-1:511042647617:key/fa5e3309-6af0-4df2-afd2-b21d480beaf4'
+    key_id = 'alias/envars'
 
     def __init__(self):
         self.cache = {}

--- a/envars/kms.py
+++ b/envars/kms.py
@@ -1,7 +1,8 @@
 import base64
 
 import boto3
-from botocore.exceptions import NoRegionError
+
+kms_client = boto3.client('kms')
 
 
 class KMSAgent(object):
@@ -13,19 +14,9 @@ class KMSAgent(object):
     def reset(self):
         self.cache = {}
 
-    @property
-    def kms_client(self):
-        if not hasattr(self, '_kms_client'):
-            try:
-                self._kms_client = boto3.client('kms')
-            except NoRegionError:
-                region_name = 'eu-west-1'
-                self._kms_client = boto3.client('kms', region_name=region_name)
-        return self._kms_client
-
     def decrypt(self, base64_ciphertext, encryption_context):
         cipher_blob = base64.b64decode(base64_ciphertext.encode('utf-8'))
-        response = self.kms_client.decrypt(
+        response = kms_client.decrypt(
             CiphertextBlob=cipher_blob,
             EncryptionContext=encryption_context,
         )
@@ -41,7 +32,7 @@ class KMSAgent(object):
         except KeyError:
             pass
 
-        response = self.kms_client.encrypt(
+        response = kms_client.encrypt(
             KeyId=self.kms_key_arn,
             Plaintext=plaintext.encode('utf-8'),
             EncryptionContext=encryption_context

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,4 @@
 argparse
-awscli
 boto3
 jinja2
 pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,8 @@
 argparse
+awscli
 boto3
 jinja2
 pip-tools
 pre-commit
+pytest
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,10 @@ argparse==1.4.0
     # via -r requirements.in
 attrs==22.2.0
     # via pytest
-awscli==1.27.80
-    # via -r requirements.in
 boto3==1.26.80
     # via -r requirements.in
 botocore==1.29.80
     # via
-    #   awscli
     #   boto3
     #   s3transfer
 build==0.10.0
@@ -23,12 +20,8 @@ cfgv==3.3.1
     # via pre-commit
 click==8.1.3
     # via pip-tools
-colorama==0.4.4
-    # via awscli
 distlib==0.3.6
     # via virtualenv
-docutils==0.16
-    # via awscli
 exceptiongroup==1.1.0
     # via pytest
 filelock==3.9.0
@@ -59,25 +52,18 @@ pluggy==1.0.0
     # via pytest
 pre-commit==3.1.1
     # via -r requirements.in
-pyasn1==0.4.8
-    # via rsa
 pyproject-hooks==1.0.0
     # via build
 pytest==7.2.1
     # via -r requirements.in
 python-dateutil==2.8.2
     # via botocore
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements.in
-    #   awscli
     #   pre-commit
-rsa==4.7.2
-    # via awscli
 s3transfer==0.6.0
-    # via
-    #   awscli
-    #   boto3
+    # via boto3
 six==1.16.0
     # via python-dateutil
 tomli==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,15 @@
 #
 argparse==1.4.0
     # via -r requirements.in
-boto3==1.26.79
+attrs==22.2.0
+    # via pytest
+awscli==1.27.80
     # via -r requirements.in
-botocore==1.29.79
+boto3==1.26.80
+    # via -r requirements.in
+botocore==1.29.80
     # via
+    #   awscli
     #   boto3
     #   s3transfer
 build==0.10.0
@@ -18,12 +23,20 @@ cfgv==3.3.1
     # via pre-commit
 click==8.1.3
     # via pip-tools
+colorama==0.4.4
+    # via awscli
 distlib==0.3.6
     # via virtualenv
+docutils==0.16
+    # via awscli
+exceptiongroup==1.1.0
+    # via pytest
 filelock==3.9.0
     # via virtualenv
 identify==2.5.18
     # via pre-commit
+iniconfig==2.0.0
+    # via pytest
 jinja2==3.1.2
     # via -r requirements.in
 jmespath==1.0.1
@@ -35,29 +48,43 @@ markupsafe==2.1.2
 nodeenv==1.7.0
     # via pre-commit
 packaging==23.0
-    # via build
+    # via
+    #   build
+    #   pytest
 pip-tools==6.12.2
     # via -r requirements.in
 platformdirs==3.0.0
     # via virtualenv
-pre-commit==3.1.0
+pluggy==1.0.0
+    # via pytest
+pre-commit==3.1.1
     # via -r requirements.in
+pyasn1==0.4.8
+    # via rsa
 pyproject-hooks==1.0.0
     # via build
+pytest==7.2.1
+    # via -r requirements.in
 python-dateutil==2.8.2
     # via botocore
-pyyaml==6.0
+pyyaml==5.4.1
     # via
     #   -r requirements.in
+    #   awscli
     #   pre-commit
+rsa==4.7.2
+    # via awscli
 s3transfer==0.6.0
-    # via boto3
+    # via
+    #   awscli
+    #   boto3
 six==1.16.0
     # via python-dateutil
 tomli==2.0.1
     # via
     #   build
     #   pyproject-hooks
+    #   pytest
 urllib3==1.26.14
     # via botocore
 virtualenv==20.19.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from botocore.stub import Stubber
+
+from envars.kms import kms_client
+
+
+@pytest.fixture(scope='function', autouse=True)
+def kms_stub():
+    with Stubber(kms_client) as stubber:
+        yield stubber
+        stubber.assert_no_pending_responses()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import subprocess
 import yaml
 
 CMD = 'python -m envars.envars'
+KKA = 'arn:aws:kms:eu-west-1:511042647617:key/fa5e3309-6af0-4df2-afd2-b21d480beaf4'
 
 
 def run_cmd(tmp_path, cmd=None):
@@ -15,15 +16,15 @@ def test_help(tmp_path):
 
 
 def test_init(tmp_path):
-    ret = run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    ret = run_cmd(tmp_path, 'init --app testapp --environments prod,staging --kms-key-arn abc')
     assert ret.returncode == 0
     with open(f'{tmp_path}/envars.yml', 'rb') as envars:
         data = envars.read().decode()
-    assert data == 'configuration:\n  APP: testapp\n  ENVIRONMENTS:\n  - prod\n  - staging\nenvironment_variables: {}\n'
+    assert data == 'configuration:\n  APP: testapp\n  ENVIRONMENTS:\n  - prod\n  - staging\n  KMS_KEY_ARN: abc\nenvironment_variables: {}\n'
 
 
 def test_add_default(tmp_path):
-    run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    run_cmd(tmp_path, f'init --app testapp --environments prod,staging --kms-key-arn {KKA}')
     ret = run_cmd(tmp_path, 'add -v TEST=test')
     assert ret.returncode == 0
     with open(f'{tmp_path}/envars.yml', 'rb') as envars:
@@ -32,7 +33,7 @@ def test_add_default(tmp_path):
 
 
 def test_add_prod(tmp_path):
-    run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    run_cmd(tmp_path, f'init --app testapp --environments prod,staging --kms-key-arn {KKA}')
     ret = run_cmd(tmp_path, 'add -e prod -v TEST=test')
     assert ret.returncode == 0
     with open(f'{tmp_path}/envars.yml', 'rb') as envars:
@@ -41,7 +42,7 @@ def test_add_prod(tmp_path):
 
 
 def test_add_prod_master(tmp_path):
-    run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    run_cmd(tmp_path, f'init --app testapp --environments prod,staging --kms-key-arn {KKA}')
     ret = run_cmd(tmp_path, 'add -e prod -a master -v TEST=test')
     assert ret.returncode == 0
     with open(f'{tmp_path}/envars.yml', 'rb') as envars:
@@ -50,19 +51,19 @@ def test_add_prod_master(tmp_path):
 
 
 def test_add_invalid_stage_fails(tmp_path):
-    run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    run_cmd(tmp_path, f'init --app testapp --environments prod,staging --kms-key-arn {KKA}')
     ret = run_cmd(tmp_path, 'add -e foo -v TEST=test')
     assert ret.returncode == 1
 
 
 def test_add_invalid_account_fails(tmp_path):
-    run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    run_cmd(tmp_path, f'init --app testapp --environments prod,staging --kms-key-arn {KKA}')
     ret = run_cmd(tmp_path, 'add -a foo -v TEST=test')
     assert ret.returncode == 1
 
 
 def test_prod_account_value_returned(tmp_path):
-    run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    run_cmd(tmp_path, f'init --app testapp --environments prod,staging --kms-key-arn {KKA}')
     run_cmd(tmp_path, 'add -v TEST=dtf')
     run_cmd(tmp_path, 'add -a master -e prod -v TEST=prod-master')
     run_cmd(tmp_path, 'add -a sandbox -e prod -v TEST=prod-sandbox')
@@ -71,7 +72,7 @@ def test_prod_account_value_returned(tmp_path):
 
 
 def test_secret(tmp_path):
-    run_cmd(tmp_path, 'init --app testapp --environments prod,staging')
+    run_cmd(tmp_path, f'init --app testapp --environments prod,staging --kms-key-arn {KKA}')
     run_cmd(tmp_path, 'add -s -v TEST=sssssh')
     ret = subprocess.run(f'{CMD} -f {tmp_path}/envars.yml print -d -e prod', shell=True, capture_output=True)
     assert ret.stdout.decode() == 'TEST=sssssh\n'


### PR DESCRIPTION
- required `--kms-key-arn` at `init`, key no longer hardcoded
- mock boto3 kms calls in tests
- add a Makefile
- update docs

The KMS key ARN is present in the tests but from my research I don't believe this is a sensitive leak.