### PR TITLE
TOPS-656 - add a newline before each var name

### DIFF
--- a/envars/models.py
+++ b/envars/models.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import jinja2
 import yaml
@@ -118,14 +119,19 @@ class EnVars:
             self.envars.append(EnVar(self, var, envars_file['environment_variables'][var], self.app, desc=desc))
 
     def save(self):
-        data = {}
-        data['configuration'] = {}
-        data['configuration']['APP'] = self.app
-        data['configuration']['ENVIRONMENTS'] = self.envs
-        data['configuration']['KMS_KEY_ARN'] = self.kms_key_arn
-        data['environment_variables'] = self.build_yaml()
         with open(self.filename, "w") as envars_yml:
-            yaml.dump(data, envars_yml, default_flow_style=False)
+            data = {}
+            data['configuration'] = {}
+            data['configuration']['APP'] = self.app
+            data['configuration']['ENVIRONMENTS'] = self.envs
+            data['configuration']['KMS_KEY_ARN'] = self.kms_key_arn
+            stream = yaml.dump(data, default_flow_style=False)
+            envars_yml.write(re.sub(r'\n  ([A-Z])', r'\n\n  \1', stream))
+            envars_yml.write('\n')
+            data = {}
+            data['environment_variables'] = self.build_yaml()
+            stream = yaml.dump(data, default_flow_style=False)
+            envars_yml.write(re.sub(r'\n  ([A-Z])', r'\n\n  \1', stream))
 
     def add(self, name, value, env_name='default', account=None, desc=None, is_secret=False):
         logging.debug(f'add({name}, {value}, {desc})')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,18 @@ def test_init(tmp_path):
     assert ret.returncode == 0
     with open(f'{tmp_path}/envars.yml', 'rb') as envars:
         data = envars.read().decode()
-    assert data == 'configuration:\n  APP: testapp\n  ENVIRONMENTS:\n  - prod\n  - staging\n  KMS_KEY_ARN: abc\nenvironment_variables: {}\n'
+    assert data == """configuration:
+
+  APP: testapp
+
+  ENVIRONMENTS:
+  - prod
+  - staging
+
+  KMS_KEY_ARN: abc
+
+environment_variables: {}
+"""
 
 
 def test_add_default(tmp_path):


### PR DESCRIPTION
pyyaml doesn't have a way to do this so this looks hacky but as the format of the file is tightly controlled we'll be ok.

improves readability of the envars.yml file