### PR TITLE
TOPS-656 - support parameter store values

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ To print the variables for a specific environment
 ```
 $ envars print --decrypt --env prod
 ```
+
+Loading a var from parameter store at runtime
+---------------------------------------------
+
+```
+MY_SPECIAL_VAR:
+  default: parameter_store:/path/VAR
+```
+
+At runtime the value of `MY_SPECIAL_VAR` will be replaced with the value from parameter store

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,18 @@ import pytest
 from botocore.stub import Stubber
 
 from envars.kms import kms_client
+from envars.models import ssm_client
 
 
 @pytest.fixture(scope='function', autouse=True)
 def kms_stub():
     with Stubber(kms_client) as stubber:
+        yield stubber
+        stubber.assert_no_pending_responses()
+
+
+@pytest.fixture(scope='function', autouse=True)
+def ssm_stub():
+    with Stubber(ssm_client) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()


### PR DESCRIPTION
in rare cases (gp-web canary) the value of an envar can't be determined until runtime, this commit enables a var to be loaded from parameter store at runtime.

Ticket: TOPS-656

Testing: added a test and will test on gp-web in Sandbox