### PR TITLE
TOPS-656 - fix = in vars for exec

### DIFF
--- a/envars/envars.py
+++ b/envars/envars.py
@@ -215,8 +215,8 @@ def execute(args):
         args.var = None
         ret = process(args)
         for val in ret:
-            matches = re.match(r'^([A-Z][A-Z|0-9|_]+)=(.*)$', val)
-            vals[matches.group(1)] = matches.group(2)
+            parts = val.split("=", 1)
+            vals[parts[0]] = parts[1]
 
     os.environ.update(vals)
     os.execlp(command[0], *command)

--- a/envars/envars.py
+++ b/envars/envars.py
@@ -215,7 +215,8 @@ def execute(args):
         args.var = None
         ret = process(args)
         for val in ret:
-            vals[val.split('=')[0]] = val.split('=')[1]
+            matches = re.match(r'^([A-Z][A-Z|0-9|_]+)=(.*)$', val)
+            vals[matches.group(1)] = matches.group(2)
 
     os.environ.update(vals)
     os.execlp(command[0], *command)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,3 +342,40 @@ def test_exec_one_var(tmp_path):
 
     assert os.environ.get('TEST') == 'test'
     assert 'STEST' not in os.environ
+
+
+def test_exec(tmp_path):
+    # used by some instance service scripts
+    run_cmd(tmp_path, 'init --app testapp --environments prod,staging --kms-key-arn abc')
+    args = type('Args', (object,), {
+        'variable': 'TEST=test',
+        'secret': False,
+        'filename': f'{tmp_path}/envars.yml',
+        'env': 'default',
+        'desc': None,
+        'account': None,
+    })
+    envars.add_var(args)
+    args = type('Args', (object,), {
+        'variable': 'STEST=stest=',
+        'secret': False,
+        'filename': f'{tmp_path}/envars.yml',
+        'env': 'default',
+        'desc': None,
+        'account': None,
+    })
+    envars.add_var(args)
+
+    args = type('Args', (object,), {
+        'account': None,
+        'command': ['printenv'],
+        'env': 'prod',
+        'filename': f'{tmp_path}/envars.yml',
+        'var': None,
+        'template_var': [],
+    })
+    envars.os.execlp = MagicMock()
+    envars.execute(args)
+
+    assert os.environ.get('TEST') == 'test'
+    assert os.environ.get('STEST') == 'stest='


### PR DESCRIPTION
`=` and anything after it was drop from variable values when using exec

exec isn't actually used anywhere in prod yet