### PR TITLE
TOPS-656 - run without valid aws creds

### DIFF
--- a/envars/envars.py
+++ b/envars/envars.py
@@ -7,14 +7,6 @@ import subprocess
 import sys
 
 import boto3
-from botocore.exceptions import NoCredentialsError, ProfileNotFound
-
-try:
-    boto3.session.Session()
-except (ProfileNotFound, NoCredentialsError):
-    print('AWS credentials not found, is AWS_PROFILE set? does "~/.aws/credentials" exist?')
-    sys.exit(1)
-
 import yaml
 
 from .models import EnVars

--- a/envars/ssm.py
+++ b/envars/ssm.py
@@ -1,0 +1,25 @@
+import sys
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError, ProfileNotFound
+
+try:
+    ssm_client = boto3.client('ssm')
+except (ProfileNotFound, NoCredentialsError):
+    print('AWS credentials not found, is AWS_PROFILE set? does "~/.aws/credentials" exist?')
+    sys.exit(1)
+
+
+class SsmAgent(object):
+
+    def fetch(self, name):
+        value = 'UNKNOWN-ERROR-FETCHING-FROM-PARAMETER-STORE'
+        try:
+            param = ssm_client.get_parameter(Name=name, WithDecryption=True)
+            value = param['Parameter']['Value']
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ParameterNotFound':
+                value = f'NOT-FOUND-IN-PSTORE-{name}'
+            elif e.response['Error']['Code'] == 'AccessDeniedException':
+                value = f'PARAMETER-STORE-ACCESS-DENIED-{name}'
+        return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from botocore.stub import Stubber
 
 from envars.kms import kms_client
-from envars.models import ssm_client
+from envars.ssm import ssm_client
 
 
 @pytest.fixture(scope='function', autouse=True)


### PR DESCRIPTION
envars shouldn't fail when AWS creds fail but aren't actually needed