### PR TITLE
update envars version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
 from setuptools import setup
 
+with open('README.md', 'r') as f:
+    long_description = f.read()
+
 setup(
     name='envars',
-    version='0.1',
-    description='A sample Python package',
+    version='1.0',
+    description='Time Out Envars',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url='https://github.com/timeoutdigital/envars',
     author='Keith Harvey',
     author_email='keith.harvey@timeout.com',
     packages=['envars'],
@@ -13,9 +19,13 @@ setup(
         'boto3',
         'jinja2',
     ],
+    extra_require={
+        'dev': ["pytest"],
+    },
     entry_points={
         'console_scripts': [
             'envars = envars.envars:main'
         ]
     },
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
This is so that a Github release number matches a package version. 

- Drops support for python < 3.8
- Also made some small updates to setup.cfg.